### PR TITLE
Fix for "TouchEvent is not defined" error in Firefox

### DIFF
--- a/projects/carousel/src/lib/slider.ts
+++ b/projects/carousel/src/lib/slider.ts
@@ -241,7 +241,7 @@ export class Slider {
   currentEventIsDisabled(event: MouseEvent | TouchEvent) {
     return (
       (event instanceof MouseEvent && !this.enableMouseDrag) ||
-      (event instanceof TouchEvent && !this.enableTouch)
+      (window.TouchEvent && event instanceof TouchEvent && !this.enableTouch)
     );
   }
 


### PR DESCRIPTION
Hello!

When using the library I've encountered an error when using Firefox (desktop version) - seems like `TouchEvent` is not defined there, at least in my case, as I don't have any touch device connected (like touch screen monitor). Example output from console:

![image](https://github.com/user-attachments/assets/0d5a411a-6b1c-4571-bc14-f17167de43cc)

This PR addresses that by checking if `TouchEvent` is defined before checking if event is an instance of `TouchEvent`.
